### PR TITLE
Remove outline: none from StyledButton

### DIFF
--- a/lib/components/Button/StyledButton.js
+++ b/lib/components/Button/StyledButton.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.StyledButton = undefined;
 
-var _templateObject = _taggedTemplateLiteral(['\n  padding: ', 'px;\n  display: inline-block;\n  cursor: pointer;\n  transition-property: opacity, filter;\n  transition-duration: 0.15s;\n  transition-timing-function: linear;\n  font: inherit;\n  color: inherit;\n  text-transform: none;\n  background-color: ', ';\n  margin: 0;\n  border: none;\n  outline: none;\n  overflow: visible;\n  ', ';\n'], ['\n  padding: ', 'px;\n  display: inline-block;\n  cursor: pointer;\n  transition-property: opacity, filter;\n  transition-duration: 0.15s;\n  transition-timing-function: linear;\n  font: inherit;\n  color: inherit;\n  text-transform: none;\n  background-color: ', ';\n  margin: 0;\n  border: none;\n  outline: none;\n  overflow: visible;\n  ', ';\n']);
+var _templateObject = _taggedTemplateLiteral(['\n  padding: ', 'px;\n  display: inline-block;\n  cursor: pointer;\n  transition-property: opacity, filter;\n  transition-duration: 0.15s;\n  transition-timing-function: linear;\n  font: inherit;\n  color: inherit;\n  text-transform: none;\n  background-color: ', ';\n  margin: 0;\n  border: none;\n  overflow: visible;\n  ', ';\n'], ['\n  padding: ', 'px;\n  display: inline-block;\n  cursor: pointer;\n  transition-property: opacity, filter;\n  transition-duration: 0.15s;\n  transition-timing-function: linear;\n  font: inherit;\n  color: inherit;\n  text-transform: none;\n  background-color: ', ';\n  margin: 0;\n  border: none;\n  overflow: visible;\n  ', ';\n']);
 
 var _styledComponents = require('styled-components');
 

--- a/src/node_modules/components/button/StyledButton.js
+++ b/src/node_modules/components/button/StyledButton.js
@@ -13,7 +13,6 @@ export const StyledButton = styled.button`
   background-color: ${({ buttonColor }) => buttonColor || 'transparent'};
   margin: 0;
   border: none;
-  outline: none;
   overflow: visible;
   ${({ buttonStyle }) => buttonStyle};
 `


### PR DESCRIPTION
Hi! I noticed that outline has been removed from button styles. It's pretty important for accessibility to always have an outline to be able to navigate by tab. And since not all users will redefine their focus styles, I think it should be included by default in this library. Let me know your thoughts.