### PR TITLE
Add aria-label

### DIFF
--- a/lib/components/Button/Button.js
+++ b/lib/components/Button/Button.js
@@ -35,7 +35,9 @@ var Button = exports.Button = function Button(props) {
     _StyledButton.StyledButton,
     _extends({
       onClick: toggleButton
-    }, { buttonWidth: buttonWidth, buttonColor: buttonColor, buttonStyle: buttonStyle, className: className }),
+    }, { buttonWidth: buttonWidth, buttonColor: buttonColor, buttonStyle: buttonStyle, className: className }, {
+      'aria-label': 'Navigation'
+    }),
     _react2.default.createElement(
       Box,
       { buttonWidth: buttonWidth },

--- a/src/node_modules/components/button/Button.js
+++ b/src/node_modules/components/button/Button.js
@@ -20,6 +20,7 @@ export const Button = props => {
     <StyledButton
       onClick={toggleButton}
       {...{ buttonWidth, buttonColor, buttonStyle, className }}
+      aria-label="Navigation"
     >
       <Box {...{ buttonWidth }}>
         <Lines {...{ buttonWidth, barColor, isActive }} />


### PR DESCRIPTION
Added `aria-label` to fix the [Google Lighthouse recommendation](https://dequeuniversity.com/rules/axe/2.2/button-name?application=lighthouse) for 'Buttons must have discernible text' 🙂 